### PR TITLE
Updated maven-gradle publish version

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -22,4 +22,4 @@ agp.version=8.1.1
 compose.version=1.5.11
 dokka.version=1.9.0
 klint.version=11.6.1
-maven-publish.version=0.25.3
+maven-publish.version=0.30.0

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.2.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.5-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
The old version 0.25.3 doesn't allow for CENTRAL_PORTAL hosting, so I updated the version